### PR TITLE
use consistent subjects

### DIFF
--- a/inst/templates/accept.txt
+++ b/inst/templates/accept.txt
@@ -1,6 +1,6 @@
 To: {{email}}
 CC: {{editor}}
-Subject: Subject: RJ {{id}}: accepted
+Subject: [RJournal {{id}}] accepted
 ---
 Dear {{name}},
 

--- a/inst/templates/acknowledge.txt
+++ b/inst/templates/acknowledge.txt
@@ -1,5 +1,5 @@
 To: {{email}}
-Subject: R Journal submission {{id}}
+Subject: [RJournal {{id}}] submission acknowledged
 ---
 Dear {{name}},
 

--- a/inst/templates/reject.txt
+++ b/inst/templates/reject.txt
@@ -1,5 +1,5 @@
 To: {{email}}
-Subject: R journal submission {{id}}
+Subject: [RJournal {{id}}] journal submission
 ---
 Dear {{name}},
 

--- a/inst/templates/review.txt
+++ b/inst/templates/review.txt
@@ -1,5 +1,5 @@
 To: {{email}}
-Subject: Review for the R journal {{id}}
+Subject: [RJournal {{id}}] Review invitation
 ---
 Dear {{firstname}},
 

--- a/inst/templates/revision-major.txt
+++ b/inst/templates/revision-major.txt
@@ -1,5 +1,5 @@
 To: {{email}}
-Subject: R journal submission {{id}}
+Subject: [RJournal {{id}}] journal submission
 ---
 Dear {{name}},
 

--- a/inst/templates/revision-minor.txt
+++ b/inst/templates/revision-minor.txt
@@ -1,5 +1,5 @@
 To: {{email}}
-Subject: R journal submission {{id}}
+Subject: [RJournal {{id}}] journal submission
 ---
 TODO: attach review comments
 TODO: change from address


### PR DESCRIPTION
I'd like to use consistent prefix of `[RJournal <id>]` in subjects to allow for easier mail filtering