### PR TITLE
Add option to not open email client

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: rj
 Title: Tools for managing the R journal
-Version: 0.2.19
+Version: 0.2.20
 Author: EiC <R-journal@r-project.org>
 Maintainer: EiC <R-journal@r-project.org>
 Description: This package provides useful functions for the

--- a/R/reviewers.R
+++ b/R/reviewers.R
@@ -49,7 +49,7 @@ add_out_for_review = function(article) {
 #' @inheritParams address
 #' @inheritParams invite_reviewers
 #' @export
-add_reviewer = function(article, name, email, invite = TRUE) {
+add_reviewer = function(article, name, email, invite = TRUE, open_email = TRUE) {
   article = as.article(article)
   reviewers = article$reviewers
   new_reviewer = address(email = email, name = name)
@@ -65,7 +65,7 @@ add_reviewer = function(article, name, email, invite = TRUE) {
     article = save_article(article)
   }
   if (isTRUE(invite)) {
-    invite_reviewer(article, reviewer_id = reviewer_id)
+    invite_reviewer(article, reviewer_id = reviewer_id, open_email = open_email)
   }
   return(invisible(article))
 }
@@ -77,21 +77,24 @@ add_reviewer = function(article, name, email, invite = TRUE) {
 #' the emails, it also caches them locally in the \code{correspodence/}
 #' directory of the corresponding article.
 #'
-#' @param article article id, like \code{"2014-01"}
-#' @param reviewer_id invite just a single reviewer
-#' @param prefix prefix added to start file name - used to distinguish
-#'   between multiple rounds of reviewers (if needed)
+#' @param article              article id, like \code{"2014-01"}
+#' @param reviewer_id          invite just a single reviewer
+#' @param prefix               prefix added to start file name - used to
+#'                             distinguish between multiple rounds of reviewers
+#'                             (if needed)
+#' @param open_email           logical value; should the function attempt to
+#'                             open the users email program; default is TRUE
 #' @export
-invite_reviewers <- function(article, prefix = "1") {
+invite_reviewers <- function(article, prefix = "1", open_email = TRUE) {
   article <- as.article(article)
   for (i in seq_along(article$reviewers)) {
-    invite_reviewer(article, i, prefix = prefix)
+    invite_reviewer(article, i, prefix = prefix, open_email = open_email)
   }
 }
 
 #' @export
 #' @rdname invite_reviewers
-invite_reviewer <- function(article, reviewer_id, prefix = "1") {
+invite_reviewer <- function(article, reviewer_id, prefix = "1", open_email = TRUE) {
   article <- as.article(article)
 
   dest <- file.path(article$path, "correspondence")
@@ -126,7 +129,7 @@ invite_reviewer <- function(article, reviewer_id, prefix = "1") {
 
   add_out_for_review(article)
 
-  email_text(email)
+  if (open_email) { email_text(email) }
 }
 
 #' @rdname invite_reviewers

--- a/man/add_reviewer.Rd
+++ b/man/add_reviewer.Rd
@@ -4,7 +4,7 @@
 \alias{add_reviewer}
 \title{Add review to DESCRIPTION}
 \usage{
-add_reviewer(article, name, email, invite = TRUE)
+add_reviewer(article, name, email, invite = TRUE, open_email = TRUE)
 }
 \arguments{
 \item{article}{article id, like \code{"2014-01"}}
@@ -14,6 +14,9 @@ add_reviewer(article, name, email, invite = TRUE)
 \item{email}{email address}
 
 \item{invite}{Automatically construct email}
+
+\item{open_email}{logical value; should the function attempt to
+open the users email program; default is TRUE}
 }
 \description{
 Add a reviewers name to the DESCRIPTION file

--- a/man/invite_reviewers.Rd
+++ b/man/invite_reviewers.Rd
@@ -6,9 +6,9 @@
 \alias{add_review}
 \title{Invite reviewer(s).}
 \usage{
-invite_reviewers(article, prefix = "1")
+invite_reviewers(article, prefix = "1", open_email = TRUE)
 
-invite_reviewer(article, reviewer_id, prefix = "1")
+invite_reviewer(article, reviewer_id, prefix = "1", open_email = TRUE)
 
 add_review(
   article,
@@ -22,8 +22,12 @@ add_review(
 \arguments{
 \item{article}{article id, like \code{"2014-01"}}
 
-\item{prefix}{prefix added to start file name - used to distinguish
-between multiple rounds of reviewers (if needed)}
+\item{prefix}{prefix added to start file name - used to
+distinguish between multiple rounds of reviewers
+(if needed)}
+
+\item{open_email}{logical value; should the function attempt to
+open the users email program; default is TRUE}
 
 \item{reviewer_id}{invite just a single reviewer}
 


### PR DESCRIPTION
As discussed on slack, there was a desire to create an email template without actually trying to open an email client. If there is a better approach to this, feel free to decline and do this another way.