### PR TITLE
ae_workload() gets a `keywords` argument

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # rj (0.3.1)
 
+- ae_workloads(keywords=FALSE) new argument
+
 # rj 0.3.0
 - Fix metadata for pandoc
 - Added texor support in article publishing workflow

--- a/R/ae_workload.R
+++ b/R/ae_workload.R
@@ -57,6 +57,7 @@ reviewer_summary <- function(articles, push = FALSE) {
 #'   workload. Retains any article where any status entry for an article is
 #'   newer than `day_back` days ago.
 #' @param active_only Toggle to show only active AEs (filtered by end year and comment field).
+#' @param keywords logical; if `TRUE`, include the keywords column from the AE file. Default is `FALSE`.
 #'
 #' @importFrom dplyr select count left_join right_join filter distinct rename bind_rows
 #' @importFrom tidyr unnest replace_na
@@ -66,7 +67,7 @@ reviewer_summary <- function(articles, push = FALSE) {
 #' ae_workload()
 #' }
 #' @export
-ae_workload <- function(articles = NULL, day_back = 365, active_only = FALSE) {
+ae_workload <- function(articles = NULL, day_back = 365, active_only = FALSE, keywords = FALSE) {
   # select only active AEs
   ae_rj <- read.csv(system.file("associate-editors.csv", package = "rj"))
 
@@ -76,8 +77,11 @@ ae_workload <- function(articles = NULL, day_back = 365, active_only = FALSE) {
     ae_rj <- ae_rj[!inactive, ]
   }
 
+  ae_cols <- c("name", "initials", "email", "comment")
+  if (isTRUE(keywords)) ae_cols <- c(ae_cols, "keywords")
+
   ae_rj <- ae_rj %>%
-    select(.data$name, .data$initials, .data$email, .data$comment) %>%
+    select(dplyr::all_of(ae_cols)) %>%
     as_tibble() %>%
     rename(status = .data$comment)
 

--- a/man/ae_workload.Rd
+++ b/man/ae_workload.Rd
@@ -5,7 +5,12 @@
 \alias{get_AE}
 \title{Check the number of articles an AE is currently working on}
 \usage{
-ae_workload(articles = NULL, day_back = 365, active_only = FALSE)
+ae_workload(
+  articles = NULL,
+  day_back = 365,
+  active_only = FALSE,
+  keywords = FALSE
+)
 
 get_AE(x)
 }
@@ -18,6 +23,8 @@ workload. Retains any article where any status entry for an article is
 newer than `day_back` days ago.}
 
 \item{active_only}{Toggle to show only active AEs (filtered by end year and comment field).}
+
+\item{keywords}{logical; if `TRUE`, include the keywords column from the AE file. Default is `FALSE`.}
 
 \item{x}{a single article, i.e. as.article("Submissions/2020-114")}
 }


### PR DESCRIPTION
I often want to have a list of AEs that includes:

- Names
- Emails
- Workload
- Keywords

The last element is not current available in the `ae_workloads()` function. This adds a `keywords` argument default to `FALSE`, so the default behavior is unchanged.